### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The control is made by a simple UIScrollView that can be scrolled horizontally t
 
 The advantage over a traditional UISegmentedControl is that with MVSelectorScrollView it's easy to select up to a dozen of values.
 
-A sample application demonstrating the usage of the control is included. The component can be used in other applications simply by dragging the MVSelectorScrollView folder into XCode.
+A sample application demonstrating the usage of the control is included. The component can be used in other applications simply by dragging the MVSelectorScrollView folder into Xcode.
 
 Preview
 -------------------------------------------------------


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
